### PR TITLE
feat(telemetry): migrate to telemetry.mcp2cli.dev, fix delivery, add insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,16 +460,18 @@ mcp2cli collects **anonymous, non-sensitive** usage telemetry to help us underst
 
 - Command category (e.g. "tool_invoke", "discover", "auth" — **never** the actual tool/prompt name)
 - Transport type used (stdio, HTTP)
+- Negotiated MCP protocol era (`legacy` 2025-11-25 vs. `modern` 2026-07-28), when a session was negotiated
 - Whether features like `--json`, `--background`, `--timeout`, daemon, profile overlay, or ad-hoc mode were used
 - Outcome (success/error) and duration in milliseconds
-- OS, architecture, and CLI version
+- OS family, architecture, and CLI version
 - A random installation UUID (not tied to your identity)
 
 ### What is NOT collected
 
 - No server endpoints, URIs, tool names, argument values, file paths, or configuration content
-- No IP addresses or user identifiers
+- No IP addresses, hostnames, usernames, or process IDs
 - No environment variables or credentials
+- No error messages — only a coarse success/error outcome
 
 ### How to opt out
 

--- a/docs/telemetry-collection.md
+++ b/docs/telemetry-collection.md
@@ -23,13 +23,43 @@ The system is designed with three principles:
 
 ## Default collector
 
-Out of the box, batched events are POSTed to
-`https://otel.mcp2cli.dev/v1/traces` as **OTLP/HTTP JSON
-spans** — the standard OpenTelemetry wire format. Any OTEL
-Collector can ingest them natively. No third-party trackers.
+Out of the box, events are converted to **OTLP/HTTP JSON spans** — the
+standard OpenTelemetry wire format — and POSTed to
+
+```text
+https://telemetry.mcp2cli.dev/v1/traces
+```
+
+the tsok observability stack's dedicated ingest endpoint (Grafana +
+Tempo/Loki/Prometheus). Any OTEL Collector can ingest the same payload
+natively. No third-party trackers.
+
+Every batch carries a `service.namespace = "mcp2cli"` **resource**
+attribute — that's what actually files the data under the mcp2cli
+project on a backend shared across multiple projects; the endpoint URL
+itself carries no project identity. If you ever redirect `telemetry.endpoint`
+at your own collector (see [Option B](#option-b-built-in-http-shipping)
+below), that attribute travels with it regardless of destination.
+
 Override the URL with `telemetry.endpoint` in your config, set it
 to `null` to keep events purely local, or opt out entirely via any
 of the mechanisms below.
+
+### Verifying the endpoint is reachable
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' -X POST \
+  https://telemetry.mcp2cli.dev/v1/traces \
+  -H 'Content-Type: application/json' --data '{"resourceSpans":[]}'
+# expect 200
+```
+
+The endpoint is OTLP/HTTP only (JSON or protobuf, no gRPC), requires no
+auth (identity is purely the resource attributes in the payload), and is
+rate-limited to 100 requests/second (200 burst) per source IP — mcp2cli's
+shipper already backs off gracefully on a `429` by simply leaving the
+batch on local disk for the next invocation to retry, so this never
+surfaces as a user-visible error.
 
 ## CLI telemetry is independent of the website
 
@@ -48,14 +78,14 @@ they both come from the same project.
 
 ## What's Collected
 
-Each CLI invocation produces one event with this schema:
+Each CLI invocation produces one event, held locally in this schema:
 
 ```json
 {
   "schema": 1,
   "installation_id": "550e8400-e29b-41d4-a716-446655440000",
   "timestamp": "2026-03-30T14:22:00Z",
-  "cli_version": "0.1.0",
+  "cli_version": "0.1.7",
   "os": "linux",
   "arch": "x86_64",
   "event": {
@@ -68,6 +98,7 @@ Each CLI invocation produces one event with this schema:
     "profile_active": true,
     "daemon_active": false,
     "ad_hoc": false,
+    "protocol_era": "modern",
     "outcome": "success",
     "duration_ms": 342
   }
@@ -81,7 +112,7 @@ Each CLI invocation produces one event with this schema:
 | `schema` | Event schema version for forward compatibility | `1` |
 | `installation_id` | Random UUID per installation — not user-identifying | UUID v4 |
 | `timestamp` | When the command ran (UTC) | ISO-8601 |
-| `cli_version` | mcp2cli version | `"0.1.0"` |
+| `cli_version` | mcp2cli version | `"0.1.7"` |
 | `os` | Operating system family | `"linux"`, `"macos"`, `"windows"` |
 | `arch` | CPU architecture | `"x86_64"`, `"aarch64"` |
 | `command_category` | What type of command (NOT the actual name) | See table below |
@@ -90,10 +121,56 @@ Each CLI invocation produces one event with this schema:
 | `background` | Whether `--background` was used | `true`/`false` |
 | `timeout_override` | Whether `--timeout` was explicitly set | `true`/`false` |
 | `profile_active` | Whether a profile overlay was in use | `true`/`false` |
-| `daemon_active` | Whether daemon mode was active | `true`/`false` |
+| `daemon_active` | Whether the invocation was routed through a running `mcp2cli daemon` | `true`/`false` |
 | `ad_hoc` | Whether `--url`/`--stdio` ad-hoc mode was used | `true`/`false` |
-| `outcome` | Result of the command | `"success"`, `"error"` |
+| `protocol_era` | Negotiated MCP protocol revision, when a session was negotiated | `"legacy"` (2025-11-25), `"modern"` (2026-07-28), absent |
+| `outcome` | Result of the command — never the error message itself | `"success"`, `"error"` |
 | `duration_ms` | Wall-clock time in milliseconds | `342` |
+
+### What actually goes over the wire
+
+The schema above is the **local** NDJSON format. When shipping to an HTTP
+endpoint, events are converted into a real OTLP/HTTP JSON `resourceSpans`
+batch — one span per event, one shared resource block per batch:
+
+```json
+{
+  "resourceSpans": [{
+    "resource": {
+      "attributes": [
+        { "key": "service.name", "value": { "stringValue": "mcp2cli-cli" } },
+        { "key": "service.namespace", "value": { "stringValue": "mcp2cli" } },
+        { "key": "service.version", "value": { "stringValue": "0.1.7" } },
+        { "key": "mcp2cli.os", "value": { "stringValue": "linux" } },
+        { "key": "mcp2cli.arch", "value": { "stringValue": "x86_64" } }
+      ]
+    },
+    "scopeSpans": [{
+      "scope": { "name": "mcp2cli.telemetry", "version": "1" },
+      "spans": [{
+        "traceId": "…", "spanId": "…",
+        "name": "command_run",
+        "startTimeUnixNano": "…", "endTimeUnixNano": "…",
+        "attributes": [
+          { "key": "mcp2cli.installation_id", "value": { "stringValue": "…" } },
+          { "key": "mcp2cli.command.category", "value": { "stringValue": "tool_invoke" } },
+          { "key": "mcp2cli.transport", "value": { "stringValue": "streamable_http" } },
+          { "key": "mcp2cli.outcome", "value": { "stringValue": "success" } },
+          { "key": "mcp2cli.protocol_era", "value": { "stringValue": "modern" } },
+          { "key": "mcp2cli.duration_ms", "value": { "intValue": "342" } }
+        ],
+        "status": { "code": 1 }
+      }]
+    }]
+  }]
+}
+```
+
+`service.namespace` and `service.name` are **resource** attributes
+(describe the sending application), not span attributes — this is
+deliberate: a dashboard that groups by project reads the resource block,
+not per-event fields. Every other collected field is a span attribute,
+namespaced under `mcp2cli.*`.
 
 ### Command Categories
 
@@ -136,7 +213,9 @@ This is explicit and permanent — these items will never be added:
 - **No file paths** — we don't know your directory structure
 - **No config content** — we don't read your YAML beyond telemetry settings
 - **No environment variables** — we don't see your credentials or secrets
-- **No IP addresses** — the local NDJSON mode has no network component
+- **No error messages or stack traces** — `outcome` is a coarse `success`/`error`, nothing more
+- **No hostname, username, or process ID** — never sent as OTel resource attributes, even though those are common conventions for other kinds of telemetry
+- **No IP addresses recorded by us** — the local NDJSON mode has no network component; the shipped HTTP request necessarily has a source IP at the transport layer like any request, but mcp2cli never reads or records it
 - **No user identifiers** — the installation_id is a random UUID
 
 ---
@@ -227,7 +306,17 @@ cat ~/.local/share/mcp2cli/telemetry_id
 
 ## Setting Up a Collection Backend
 
-The mcp2cli telemetry system is vendor-agnostic. Events are NDJSON — any system that accepts JSON can be a backend.
+The mcp2cli telemetry system is vendor-agnostic. Locally, events are
+NDJSON — any system that accepts JSON can be a backend. Two different
+integration points below, don't confuse them:
+
+- **Option A and C–F** read `telemetry.ndjson` directly, on their own
+  schedule (a cron job, a manual relay script, …) — they never touch
+  mcp2cli's own HTTP shipping and can use whatever wire format you want,
+  since you own both ends.
+- **Option B** reconfigures mcp2cli's *built-in* shipper (the one that
+  talks to the default collector by default) to POST to your URL instead
+  — that one always sends real OTLP/HTTP JSON, never a bespoke format.
 
 ### Architecture Options
 
@@ -339,26 +428,33 @@ http.createServer((req, res) => {
 
 ### Option B: Built-in HTTP Shipping
 
-Configure the mcp2cli to POST events directly to your endpoint:
+Redirect mcp2cli's own shipper — the same one that talks to the default
+collector — at your endpoint instead:
 
 ```yaml
 telemetry:
   enabled: true
-  endpoint: "https://your-collector.example.com/v1/events"
+  endpoint: "https://your-collector.example.com/v1/traces"
   batch_size: 25
 ```
 
-Events are batched locally and shipped as a JSON array when the batch is full. The endpoint receives:
+Unlike Options A and C–F below (which read the local NDJSON file
+independently, on your own schedule), this is what mcp2cli's *built-in*
+shipper sends, to whatever URL you configure. It always sends a real
+**OTLP/HTTP JSON `resourceSpans` batch** — see [What actually goes over
+the wire](#what-actually-goes-over-the-wire) above for the exact shape —
+not a plain JSON array of the local event schema. `batch_size` caps how
+many pending local events go into one POST; a batch is attempted on every
+invocation that has something pending, not only once `batch_size` is
+reached. Your collector needs to speak OTLP/HTTP (any OpenTelemetry
+Collector receiver does this natively) or translate it — see the
+[OTLP/HTTP spec](https://opentelemetry.io/docs/specs/otlp/#otlphttp) if
+you're writing a custom one.
 
-```http
-POST /v1/events HTTP/1.1
-Content-Type: application/json
-
-[
-  {"schema":1,"installation_id":"...","event":{"type":"command_run",...}},
-  {"schema":1,"installation_id":"...","event":{"type":"command_run",...}}
-]
-```
+A shipping attempt only removes events from the local file after a
+confirmed `2xx` response; any other outcome (network error, timeout,
+non-2xx status) leaves them in place for the next invocation to retry, so
+a temporarily unreachable collector never loses data.
 
 ---
 
@@ -656,6 +752,8 @@ Use this checklist to verify the telemetry implementation meets privacy requirem
 - [ ] Events contain no argument values or payloads
 - [ ] Events contain no file paths
 - [ ] Events contain no environment variables
+- [ ] Events contain no error messages or stack traces (`outcome` only)
+- [ ] Shipped OTLP resource attributes contain no hostname, username, or process ID
 - [ ] Installation ID is a random UUID (not derived from user info)
 - [ ] Opt-out via config works (`telemetry.enabled: false`)
 - [ ] Opt-out via env var works (`MCP2CLI_TELEMETRY=off`)

--- a/site/src/lib/site-telemetry.ts
+++ b/site/src/lib/site-telemetry.ts
@@ -1,11 +1,14 @@
 /**
  * Browser-side OpenTelemetry for mcp2cli.dev.
  *
- * Emits OTLP/HTTP JSON spans to the same OTEL Collector the CLI
- * uses (`https://otel.mcp2cli.dev/v1/traces`), but with its own
- * `service.name = "mcp2cli-site"` and a session-scoped anonymous
- * session id. No identifier leaks to the CLI or the installer —
- * each surface has its own independent telemetry stream.
+ * Emits OTLP/HTTP JSON spans to the same tsok observability stack the
+ * CLI uses (`https://telemetry.mcp2cli.dev/v1/traces`), tagged with
+ * `service.namespace = "mcp2cli"` (the resource attribute that actually
+ * files data under the mcp2cli project on the shared backend — the
+ * endpoint URL alone does not) plus its own `service.name =
+ * "mcp2cli-site"` and a session-scoped anonymous session id. No
+ * identifier leaks to the CLI or the installer — each surface has its
+ * own independent telemetry stream.
  *
  * Opt-out signals respected before any span is ever emitted:
  *   - `navigator.doNotTrack === '1'`
@@ -19,7 +22,8 @@ import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 
-const OTLP_ENDPOINT = 'https://otel.mcp2cli.dev/v1/traces';
+const OTLP_ENDPOINT = 'https://telemetry.mcp2cli.dev/v1/traces';
+const SERVICE_NAMESPACE = 'mcp2cli';
 const SERVICE_NAME = 'mcp2cli-site';
 const TRACER_NAME = 'mcp2cli.site';
 
@@ -69,6 +73,7 @@ export function initSiteTelemetry(): void {
   const provider = new WebTracerProvider({
     resource: resourceFromAttributes({
       'service.name': SERVICE_NAME,
+      'service.namespace': SERVICE_NAMESPACE,
       'service.version': '0.1.0',
       'session.id': sessionId,
     }),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -151,12 +151,20 @@ pub async fn run(state: AppState) -> Result<()> {
             has_json,
             has_bg,
             has_timeout,
-            false, // profile detection would require config access
-            false, // daemon detection would require runtime check
+            state.runtime.profile_active(),
+            state.runtime.daemon_active(),
             ad_hoc,
+            state.runtime.negotiated_protocol_era().await,
             outcome,
             timer.elapsed(),
         );
+
+        // The user's output is already on screen by this point — this
+        // only bounds how much longer the process takes to actually
+        // exit, giving the shipping thread spawned by record_command a
+        // real (short) chance to complete before it would otherwise be
+        // killed outright at process exit. See TelemetryRecorder::flush.
+        recorder.flush();
     }
 
     result

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -62,6 +62,24 @@ use crate::{mcp::model::TransportKind, output::OutputFormat};
 /// in the config tree (double-underscore is the nesting separator).
 const ENV_PREFIX: &str = "MCP2CLI_";
 
+/// Build the figment env provider for `MCP2CLI_*` overrides.
+///
+/// Excludes the bare `MCP2CLI_TELEMETRY` key: it's documented and
+/// tested as a simple on/off toggle
+/// (`crate::telemetry::TelemetryRecorder::is_enabled`), read directly
+/// from the process environment rather than through this merge. Without
+/// this exclusion, figment sees `MCP2CLI_TELEMETRY` as an override for
+/// the whole nested `telemetry` config *struct* (it shares a name with
+/// that section) and fails to deserialize the string `"off"` as one —
+/// which previously broke config loading outright for any command that
+/// set this env var, defeating the opt-out it was meant to provide.
+/// Nested overrides (`MCP2CLI_TELEMETRY__ENABLED=false`) are unaffected:
+/// `.split("__")` turns those into `"telemetry.enabled"`, which doesn't
+/// match the ignored bare key `"telemetry"`.
+fn env_provider() -> Env {
+    Env::prefixed(ENV_PREFIX).ignore(&["telemetry"]).split("__")
+}
+
 /// Root configuration model for a named MCP server binding.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AppConfig {
@@ -132,7 +150,7 @@ impl AppConfig {
 
         let mut figment = Figment::from(Serialized::defaults(AppConfig::default()));
         figment = figment.merge(Yaml::file(&config_path));
-        figment = figment.merge(Env::prefixed(ENV_PREFIX).split("__"));
+        figment = figment.merge(env_provider());
 
         let mut config: AppConfig = figment
             .extract()
@@ -825,6 +843,87 @@ mod tests {
             )
         );
         assert_eq!(loaded.config.plugins.search_dirs, Vec::<String>::new());
+    }
+
+    /// Regression test: `MCP2CLI_TELEMETRY=off` is documented and tested
+    /// (`telemetry::tests::disabled_by_env`) as a simple on/off toggle,
+    /// read directly from the environment by
+    /// `TelemetryRecorder::is_enabled`. But it shares a name with the
+    /// `telemetry` config section, and figment's env provider used to
+    /// merge it as an override for that whole nested struct — trying to
+    /// deserialize the string `"off"` as a `TelemetryConfig` and failing,
+    /// which broke config loading outright for every command that set
+    /// this env var. `env_provider()` now excludes the bare key.
+    ///
+    /// SAFETY: test-only env mutation; not behind a lock like the
+    /// telemetry/tls module tests use for the same variable, so a run
+    /// with `disabled_by_env` in `telemetry::tests` interleaved on
+    /// another thread could in principle race — accepted here to match
+    /// this codebase's existing convention for env-var tests.
+    #[test]
+    fn bare_telemetry_env_var_does_not_break_config_loading() {
+        let root = test_tempdir();
+        let layout = RuntimeLayout {
+            config_root: root.path().join("config"),
+            data_root: root.path().join("data"),
+            link_root: root.path().join("bin"),
+        };
+        write_named_config(
+            &layout,
+            &ConfigCreateOptions {
+                name: "telemetry-env".to_owned(),
+                app_profile: "bridge".to_owned(),
+                transport: TransportKind::StreamableHttp,
+                endpoint: Some("https://example.com/mcp".to_owned()),
+                protocol_version: None,
+                stdio_command: None,
+                stdio_args: Vec::new(),
+                force: false,
+            },
+        )
+        .expect("config should be created");
+
+        unsafe {
+            std::env::set_var("MCP2CLI_TELEMETRY", "off");
+        }
+        let loaded = AppConfig::load_named("telemetry-env", None, &layout);
+        unsafe {
+            std::env::remove_var("MCP2CLI_TELEMETRY");
+        }
+        loaded.expect("bare MCP2CLI_TELEMETRY=off must not break config loading");
+    }
+
+    #[test]
+    fn nested_telemetry_env_override_still_reaches_the_config() {
+        let root = test_tempdir();
+        let layout = RuntimeLayout {
+            config_root: root.path().join("config"),
+            data_root: root.path().join("data"),
+            link_root: root.path().join("bin"),
+        };
+        write_named_config(
+            &layout,
+            &ConfigCreateOptions {
+                name: "telemetry-nested".to_owned(),
+                app_profile: "bridge".to_owned(),
+                transport: TransportKind::StreamableHttp,
+                endpoint: Some("https://example.com/mcp".to_owned()),
+                protocol_version: None,
+                stdio_command: None,
+                stdio_args: Vec::new(),
+                force: false,
+            },
+        )
+        .expect("config should be created");
+
+        unsafe {
+            std::env::set_var("MCP2CLI_TELEMETRY__ENABLED", "false");
+        }
+        let loaded = AppConfig::load_named("telemetry-nested", None, &layout);
+        unsafe {
+            std::env::remove_var("MCP2CLI_TELEMETRY__ENABLED");
+        }
+        assert!(!loaded.expect("config should load").config.telemetry.enabled);
     }
 
     #[test]

--- a/src/mcp/client.rs
+++ b/src/mcp/client.rs
@@ -119,6 +119,14 @@ pub trait McpClient: Send + Sync {
         let _ = (request_id, reason);
         Ok(()) // default no-op for transports that don't support it
     }
+
+    /// Whether this invocation was routed through a running `mcp2cli
+    /// daemon` (a warm, already-negotiated connection) rather than
+    /// connecting fresh. Used only for the coarse `daemon_active`
+    /// telemetry dimension — never anything identifying the daemon.
+    fn is_daemon(&self) -> bool {
+        false
+    }
 }
 
 /// Perform an MCP operation with an optional timeout.
@@ -4072,5 +4080,9 @@ impl McpClient for DaemonMcpClient {
         _inventory_stale_path: Option<&std::path::PathBuf>,
     ) -> Result<McpOperationResult> {
         crate::runtime::daemon::daemon_perform(&self.socket_path, &operation).await
+    }
+
+    fn is_daemon(&self) -> bool {
+        true
     }
 }

--- a/src/runtime/host.rs
+++ b/src/runtime/host.rs
@@ -100,6 +100,34 @@ impl RuntimeHost {
         }
     }
 
+    /// Whether a profile overlay is active for the selected config.
+    /// Telemetry-only signal — never the profile's name or content.
+    pub fn profile_active(&self) -> bool {
+        self.selected_config
+            .as_ref()
+            .is_some_and(|config| config.config.profile.is_some())
+    }
+
+    /// Whether this invocation is routed through a running `mcp2cli
+    /// daemon` rather than a fresh connection.
+    pub fn daemon_active(&self) -> bool {
+        self.mcp_client.is_daemon()
+    }
+
+    /// The negotiated MCP protocol era (`"legacy"` or `"modern"`) for the
+    /// active session, if one has been negotiated. `None` covers every
+    /// case where the concept doesn't apply: host commands, ad-hoc
+    /// connections that never reached a server, and daemon-routed calls
+    /// (the daemon IPC protocol doesn't currently surface it).
+    /// Telemetry-only — a coarse two-value signal, never a server
+    /// identity or endpoint.
+    pub async fn negotiated_protocol_era(&self) -> Option<&'static str> {
+        self.mcp_client
+            .negotiated_session()
+            .await
+            .map(|session| session.era.as_str())
+    }
+
     pub async fn run(&self, target: DispatchTarget) -> Result<()> {
         match target {
             DispatchTarget::AppConfig {

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -6,18 +6,29 @@
 //! ## Privacy guarantees
 //! - No server endpoints, URIs, arguments, or tool names are recorded.
 //! - The installation ID is a random UUID (not derived from user identity).
+//! - No resource attribute identifies the machine or user (no hostname,
+//!   username, or process id) — only the coarse platform family already
+//!   in [`TelemetryEvent::os`]/[`TelemetryEvent::arch`].
 //! - Telemetry is opt-out: disable via config, env var, or CLI flag.
 //!
 //! ## Data flow
 //! 1. Each command invocation produces a [`TelemetryEvent`].
 //! 2. Events are appended to a local NDJSON file (`telemetry.ndjson`).
-//! 3. Optionally, events are batched and POSTed to a configurable HTTP endpoint.
+//! 3. Optionally, events are converted to an OTLP/HTTP JSON `resourceSpans`
+//!    batch (see [`to_otlp_payload`]) and POSTed to a configurable
+//!    endpoint, tagged with `service.namespace` so the shared backend
+//!    files them under the right project.
+//! 4. [`TelemetryRecorder::flush`] gives that POST a short bounded window
+//!    to finish before the process exits, since a detached shipping
+//!    thread would otherwise be killed mid-flight by a short-lived CLI
+//!    invocation — see its doc comment for why this matters.
 
 use std::{
     fs::{self, OpenOptions},
     io::Write,
     path::{Path, PathBuf},
-    sync::OnceLock,
+    sync::{Mutex, OnceLock},
+    thread::JoinHandle,
     time::{Duration, Instant},
 };
 
@@ -40,8 +51,8 @@ pub struct TelemetryConfig {
     #[serde(default = "default_enabled")]
     pub enabled: bool,
 
-    /// HTTP endpoint for shipping events as JSON batches.
-    /// Defaults to the first-party `otel.mcp2cli.dev/v1/traces`
+    /// OTLP/HTTP endpoint events are shipped to as `resourceSpans`
+    /// batches. Defaults to the first-party `telemetry.mcp2cli.dev`
     /// collector; can be overridden in user/app config or set to
     /// `null` to keep events purely local.
     #[serde(default = "default_endpoint")]
@@ -66,13 +77,22 @@ fn default_enabled() -> bool {
     true
 }
 
-/// Default collector URL. First-party, hosted on the mcp2cli.dev
-/// zone; speaks the standard OTLP/HTTP trace-ingest protocol so any
-/// OpenTelemetry Collector sitting behind it can receive us
-/// natively. Sending is opt-out via the usual mechanisms:
-/// `telemetry.enabled: false` in config, `MCP2CLI_TELEMETRY=off`,
-/// `DO_NOT_TRACK=1`, or `--no-telemetry`.
-pub const DEFAULT_TELEMETRY_ENDPOINT: &str = "https://otel.mcp2cli.dev/v1/traces";
+/// Default collector URL — the tsok observability stack's dedicated
+/// mcp2cli ingest endpoint (Grafana + Tempo/Loki/Prometheus behind
+/// `telemetry.mcp2cli.dev`). Speaks standard OTLP/HTTP JSON, so any
+/// OpenTelemetry Collector can receive us natively. Data is filed under
+/// this project by the `service.namespace` resource attribute (see
+/// [`to_otlp_payload`]) — the endpoint itself does not scope the data.
+/// Sending is opt-out via the usual mechanisms: `telemetry.enabled:
+/// false` in config, `MCP2CLI_TELEMETRY=off`, `DO_NOT_TRACK=1`, or
+/// `--no-telemetry`.
+pub const DEFAULT_TELEMETRY_ENDPOINT: &str = "https://telemetry.mcp2cli.dev/v1/traces";
+
+/// OTel resource attribute that files this app's telemetry under the
+/// `mcp2cli` project on the shared backend. MUST be a resource
+/// attribute (not a span attribute) or the collector's dashboards won't
+/// group the data — see [`to_otlp_payload`].
+const OTEL_SERVICE_NAMESPACE: &str = "mcp2cli";
 
 fn default_endpoint() -> Option<String> {
     Some(DEFAULT_TELEMETRY_ENDPOINT.to_string())
@@ -135,6 +155,13 @@ pub enum EventKind {
         daemon_active: bool,
         /// Whether this was an ad-hoc (--url/--stdio) invocation.
         ad_hoc: bool,
+        /// Negotiated MCP protocol era, when a session was negotiated:
+        /// "legacy" (2025-11-25 initialize handshake) or "modern"
+        /// (2026-07-28 stateless). `None` for host commands, ad-hoc
+        /// connections that never reached a server, and daemon-routed
+        /// calls.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        protocol_era: Option<String>,
         /// Outcome: "success" or "error".
         outcome: String,
         /// Duration in milliseconds.
@@ -173,11 +200,25 @@ pub fn get_or_create_installation_id(data_root: &Path) -> String {
 // Recorder
 // ---------------------------------------------------------------------------
 
+/// How long [`TelemetryRecorder::flush`] waits for in-flight shipping
+/// threads before letting the process exit anyway. Detached
+/// `std::thread::spawn` threads are killed outright when the process
+/// exits, so without a bounded wait here a short-lived CLI invocation
+/// almost never gives its own shipping attempt enough time to complete
+/// a network round trip — events would accumulate locally but rarely
+/// actually ship. Short enough that a dead or slow collector can't
+/// meaningfully delay the shell prompt returning; the user's command
+/// output is already printed by this point regardless.
+const SHIP_FLUSH_TIMEOUT: Duration = Duration::from_millis(250);
+
 /// Handles recording telemetry events to local file and optional remote endpoint.
 pub struct TelemetryRecorder {
     config: TelemetryConfig,
     data_root: PathBuf,
     installation_id: String,
+    /// Handles of detached shipping threads spawned by [`Self::persist`]
+    /// that haven't been waited on yet. Drained by [`Self::flush`].
+    pending_ships: Mutex<Vec<JoinHandle<()>>>,
 }
 
 impl TelemetryRecorder {
@@ -191,7 +232,34 @@ impl TelemetryRecorder {
             config: config.clone(),
             data_root: data_root.to_path_buf(),
             installation_id,
+            pending_ships: Mutex::new(Vec::new()),
         })
+    }
+
+    /// Give any in-flight background shipping threads a short, bounded
+    /// window ([`SHIP_FLUSH_TIMEOUT`]) to finish. Call once, right
+    /// before the process would otherwise exit. A thread that hasn't
+    /// finished within the window is simply left running — it dies with
+    /// the process exactly as it would have without this call — and its
+    /// events remain on local disk (only a confirmed 2xx truncates them)
+    /// for the next invocation to retry.
+    pub fn flush(&self) {
+        let handles = {
+            let mut pending = self
+                .pending_ships
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            std::mem::take(&mut *pending)
+        };
+        let deadline = Instant::now() + SHIP_FLUSH_TIMEOUT;
+        for handle in handles {
+            while !handle.is_finished() && Instant::now() < deadline {
+                std::thread::sleep(Duration::from_millis(5));
+            }
+            if handle.is_finished() {
+                let _ = handle.join();
+            }
+        }
     }
 
     /// Check whether telemetry should be enabled, considering config, env, and global flag.
@@ -232,6 +300,7 @@ impl TelemetryRecorder {
         profile_active: bool,
         daemon_active: bool,
         ad_hoc: bool,
+        protocol_era: Option<&str>,
         outcome: &str,
         duration: Duration,
     ) {
@@ -244,6 +313,7 @@ impl TelemetryRecorder {
             profile_active,
             daemon_active,
             ad_hoc,
+            protocol_era: protocol_era.map(str::to_owned),
             outcome: outcome.to_string(),
             duration_ms: duration.as_millis() as u64,
         });
@@ -364,10 +434,14 @@ impl TelemetryRecorder {
         let path_clone = path.clone();
         let cli_version = env!("CARGO_PKG_VERSION").to_string();
 
-        // Fire-and-forget on a detached std::thread so the CLI returns
-        // to the user immediately. A short timeout means a dead
-        // collector never blocks past a few seconds of background work.
-        std::thread::spawn(move || {
+        // Runs on a detached std::thread so the CLI's actual work never
+        // waits on network I/O — [`Self::flush`] later gives this thread
+        // a short bounded window to finish before the process exits,
+        // rather than the process racing ahead and simply killing it.
+        // The 2s/5s timeouts here are an independent upper bound in case
+        // the thread outlives that flush window (best-effort
+        // continuation); they don't block the CLI itself.
+        let handle = std::thread::spawn(move || {
             let user_agent = format!("mcp2cli/{cli_version}");
             let agent = ureq::AgentBuilder::new()
                 .timeout_connect(Duration::from_secs(2))
@@ -396,6 +470,9 @@ impl TelemetryRecorder {
                 }
             }
         });
+        if let Ok(mut pending) = self.pending_ships.lock() {
+            pending.push(handle);
+        }
     }
 }
 
@@ -439,11 +516,20 @@ fn rfc3339_to_ns(ts: &str) -> u64 {
 /// of parsed [`TelemetryEvent`]s. One resource block, one scope,
 /// one span per event.
 fn to_otlp_payload(events: &[TelemetryEvent]) -> serde_json::Value {
-    // Resource attributes are common to all spans in this batch —
-    // they describe the sending service, not any individual event.
+    // Resource attributes are common to all spans in this batch — they
+    // describe the sending service, not any individual event.
+    //
+    // `service.namespace` is the field that actually files this data
+    // under the mcp2cli project on the shared backend; the endpoint URL
+    // itself carries no project identity. Deliberately absent: any
+    // resource attribute that would identify the machine or user
+    // (hostname, process id, username, detailed OS version banner) —
+    // `mcp2cli.os`/`mcp2cli.arch` stay at the coarse platform-family
+    // granularity already used locally (see `TelemetryEvent::os`/`arch`).
     let first = events.first();
     let resource_attributes = serde_json::json!([
         str_attr("service.name", "mcp2cli-cli"),
+        str_attr("service.namespace", OTEL_SERVICE_NAMESPACE),
         str_attr(
             "service.version",
             first
@@ -451,11 +537,11 @@ fn to_otlp_payload(events: &[TelemetryEvent]) -> serde_json::Value {
                 .unwrap_or(env!("CARGO_PKG_VERSION"))
         ),
         str_attr(
-            "host.os",
+            "mcp2cli.os",
             first.map(|e| e.os.as_str()).unwrap_or(std::env::consts::OS)
         ),
         str_attr(
-            "host.arch",
+            "mcp2cli.arch",
             first
                 .map(|e| e.arch.as_str())
                 .unwrap_or(std::env::consts::ARCH)
@@ -491,6 +577,7 @@ fn event_to_span(event: &TelemetryEvent) -> serde_json::Value {
             profile_active,
             daemon_active,
             ad_hoc,
+            protocol_era,
             outcome,
             duration_ms,
         } => {
@@ -503,6 +590,9 @@ fn event_to_span(event: &TelemetryEvent) -> serde_json::Value {
             attributes.push(bool_attr("mcp2cli.profile_active", *profile_active));
             attributes.push(bool_attr("mcp2cli.daemon_active", *daemon_active));
             attributes.push(bool_attr("mcp2cli.ad_hoc", *ad_hoc));
+            if let Some(era) = protocol_era {
+                attributes.push(str_attr("mcp2cli.protocol_era", era));
+            }
             attributes.push(int_attr("mcp2cli.duration_ms", *duration_ms));
             let status = if outcome == "success" { 1 } else { 2 };
             ("command_run", status, *duration_ms * 1_000_000)
@@ -553,6 +643,7 @@ pub fn command_category(command_name: &str) -> &str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::thread;
     use tempfile::TempDir;
 
     #[test]
@@ -629,6 +720,7 @@ mod tests {
             false,
             false,
             false,
+            Some("modern"),
             "success",
             Duration::from_millis(150),
         );
@@ -640,11 +732,13 @@ mod tests {
                 command_category,
                 outcome,
                 duration_ms,
+                protocol_era,
                 ..
             } => {
                 assert_eq!(command_category, "tool_invoke");
                 assert_eq!(outcome, "success");
                 assert_eq!(*duration_ms, 150);
+                assert_eq!(protocol_era.as_deref(), Some("modern"));
             }
             _ => panic!("expected CommandRun event"),
         }
@@ -685,6 +779,7 @@ mod tests {
                 profile_active: true,
                 daemon_active: false,
                 ad_hoc: false,
+                protocol_era: Some("legacy".to_string()),
                 outcome: "success".to_string(),
                 duration_ms: 42,
             },
@@ -693,5 +788,225 @@ mod tests {
         let parsed: TelemetryEvent = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.schema, 1);
         assert_eq!(parsed.installation_id, "test-id");
+    }
+
+    fn sample_event(protocol_era: Option<&str>) -> TelemetryEvent {
+        TelemetryEvent {
+            schema: 1,
+            installation_id: "test-id".to_string(),
+            timestamp: "2026-01-01T00:00:00Z".to_string(),
+            cli_version: "9.9.9".to_string(),
+            os: "linux".to_string(),
+            arch: "x86_64".to_string(),
+            event: EventKind::CommandRun {
+                command_category: "discover".to_string(),
+                transport: "stdio".to_string(),
+                json_output: true,
+                background: false,
+                timeout_override: false,
+                profile_active: true,
+                daemon_active: false,
+                ad_hoc: false,
+                protocol_era: protocol_era.map(str::to_owned),
+                outcome: "success".to_string(),
+                duration_ms: 42,
+            },
+        }
+    }
+
+    fn resource_attributes(payload: &serde_json::Value) -> &Vec<serde_json::Value> {
+        payload["resourceSpans"][0]["resource"]["attributes"]
+            .as_array()
+            .expect("resource attributes should be an array")
+    }
+
+    fn attr_str_value<'a>(attributes: &'a [serde_json::Value], key: &str) -> Option<&'a str> {
+        attributes
+            .iter()
+            .find(|attribute| attribute["key"] == key)?
+            .get("value")?
+            .get("stringValue")?
+            .as_str()
+    }
+
+    #[test]
+    fn otlp_payload_files_data_under_the_mcp2cli_project() {
+        // service.namespace is the field that actually routes this data
+        // to the mcp2cli project on the shared backend — the endpoint
+        // URL itself carries no project identity, so this attribute
+        // being present and correct is the single most important
+        // correctness property of the payload.
+        let payload = to_otlp_payload(&[sample_event(Some("modern"))]);
+        let attributes = resource_attributes(&payload);
+        assert_eq!(
+            attr_str_value(attributes, "service.namespace"),
+            Some("mcp2cli")
+        );
+        assert_eq!(
+            attr_str_value(attributes, "service.name"),
+            Some("mcp2cli-cli")
+        );
+        assert_eq!(attr_str_value(attributes, "service.version"), Some("9.9.9"));
+    }
+
+    #[test]
+    fn otlp_payload_resource_attributes_carry_no_identifying_data() {
+        // Explicit negative check: no hostname, username, process id, or
+        // any other machine/user-identifying resource attribute — only
+        // the coarse platform family the local schema already exposes.
+        let payload = to_otlp_payload(&[sample_event(None)]);
+        let attributes = resource_attributes(&payload);
+        let keys: Vec<&str> = attributes
+            .iter()
+            .filter_map(|attribute| attribute["key"].as_str())
+            .collect();
+        for forbidden in [
+            "host.name",
+            "host.id",
+            "process.pid",
+            "user.name",
+            "os.description",
+        ] {
+            assert!(
+                !keys.contains(&forbidden),
+                "resource attributes must not include '{forbidden}': {keys:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn otlp_span_includes_protocol_era_only_when_negotiated() {
+        let with_era = event_to_span(&sample_event(Some("legacy")));
+        let span_attrs = with_era["attributes"].as_array().unwrap();
+        assert_eq!(
+            attr_str_value(span_attrs, "mcp2cli.protocol_era"),
+            Some("legacy")
+        );
+
+        let without_era = event_to_span(&sample_event(None));
+        let span_attrs = without_era["attributes"].as_array().unwrap();
+        assert!(attr_str_value(span_attrs, "mcp2cli.protocol_era").is_none());
+    }
+
+    #[test]
+    fn default_endpoint_targets_the_dedicated_telemetry_host() {
+        assert_eq!(
+            DEFAULT_TELEMETRY_ENDPOINT,
+            "https://telemetry.mcp2cli.dev/v1/traces"
+        );
+    }
+
+    /// Accept one HTTP POST on a localhost listener and reply 200 OK.
+    /// Stands in for the collector so shipping can be exercised without
+    /// a real network call.
+    fn accept_one_and_reply_ok(listener: std::net::TcpListener) {
+        use std::io::Read;
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut buf = [0_u8; 8192];
+        // Best-effort drain — we don't need the body, just to let the
+        // client finish writing before we reply.
+        let _ = stream.set_read_timeout(Some(Duration::from_secs(2)));
+        let _ = stream.read(&mut buf);
+        let _ =
+            stream.write_all(b"HTTP/1.1 200 OK\r\ncontent-length: 0\r\nconnection: close\r\n\r\n");
+    }
+
+    #[test]
+    fn flush_waits_for_shipping_to_actually_complete() {
+        // Regression test: a detached std::thread spawned to ship events
+        // is killed outright when the process exits, so without a
+        // bounded wait a short-lived CLI invocation almost never gives
+        // it time to finish. This proves record_command + flush() leaves
+        // the local file empty against a real (if local) HTTP round
+        // trip, not just that the code compiles.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = thread::spawn(move || accept_one_and_reply_ok(listener));
+
+        let tmp = TempDir::new().unwrap();
+        let config = TelemetryConfig {
+            endpoint: Some(format!("http://{addr}/v1/traces")),
+            ..TelemetryConfig::default()
+        };
+        // SAFETY: test-only
+        unsafe {
+            std::env::remove_var("MCP2CLI_TELEMETRY");
+            std::env::remove_var("DO_NOT_TRACK");
+        }
+        let recorder = TelemetryRecorder::new(&config, tmp.path()).unwrap();
+        recorder.record_command(
+            "tool_invoke",
+            "streamable_http",
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            None,
+            "success",
+            Duration::from_millis(10),
+        );
+        recorder.flush();
+
+        server.join().unwrap();
+        let content = fs::read_to_string(tmp.path().join("telemetry.ndjson")).unwrap_or_default();
+        assert!(
+            content.is_empty(),
+            "expected the shipped event to be truncated from disk, got: {content:?}"
+        );
+    }
+
+    #[test]
+    fn flush_returns_promptly_when_the_collector_never_responds() {
+        // The other half of the contract: flush() must not hang forever
+        // waiting on a dead/slow collector — it bounds the wait and lets
+        // the process exit anyway, leaving the event safely on disk.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        // Accept the connection but never reply — simulates a collector
+        // that's up but hung.
+        let _server = thread::spawn(move || {
+            let _ = listener.accept();
+            thread::sleep(Duration::from_secs(10));
+        });
+
+        let tmp = TempDir::new().unwrap();
+        let config = TelemetryConfig {
+            endpoint: Some(format!("http://{addr}/v1/traces")),
+            ..TelemetryConfig::default()
+        };
+        // SAFETY: test-only
+        unsafe {
+            std::env::remove_var("MCP2CLI_TELEMETRY");
+            std::env::remove_var("DO_NOT_TRACK");
+        }
+        let recorder = TelemetryRecorder::new(&config, tmp.path()).unwrap();
+        recorder.record_command(
+            "tool_invoke",
+            "streamable_http",
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            None,
+            "success",
+            Duration::from_millis(10),
+        );
+
+        let started = Instant::now();
+        recorder.flush();
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "flush() should bound its wait, took {:?}",
+            started.elapsed()
+        );
+
+        // The event is still there — it was never shipped — ready for
+        // the next invocation to retry.
+        let content = fs::read_to_string(tmp.path().join("telemetry.ndjson")).unwrap();
+        assert!(!content.is_empty());
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -800,6 +800,7 @@ fn config_equals_form_works() {
     let mut cmd = assert_cmd::Command::cargo_bin("mcp2cli").expect("binary should be built");
     cmd.env("MCP2CLI_CONFIG_DIR", fixture.config_dir());
     cmd.env("MCP2CLI_DATA_DIR", fixture.data_dir());
+    cmd.env("MCP2CLI_TELEMETRY", "off");
     cmd.arg("equalsform");
     cmd.arg(format!("--config={}", config_path.display()));
     cmd.arg("discover");

--- a/tests/mcp_shim_cli.rs
+++ b/tests/mcp_shim_cli.rs
@@ -21,6 +21,8 @@ fn spawn_as(argv0: &str, args: &[&str], envs: &[(&str, &std::path::Path)]) -> st
     for (k, v) in envs {
         cmd.env(k, v);
     }
+    // Never make real network calls to production telemetry infra in tests.
+    cmd.env("MCP2CLI_TELEMETRY", "off");
     cmd.output().expect("spawn mcp2cli")
 }
 

--- a/tests/support.rs
+++ b/tests/support.rs
@@ -123,6 +123,12 @@ pub fn mcp2cli_cmd(fixture: &TestFixture) -> assert_cmd::Command {
     let mut cmd = assert_cmd::Command::cargo_bin("mcp2cli").expect("binary should be built");
     cmd.env("MCP2CLI_CONFIG_DIR", fixture.config_dir());
     cmd.env("MCP2CLI_DATA_DIR", fixture.data_dir());
+    // Integration tests must never make real network calls to production
+    // telemetry infrastructure — the endpoint is now genuinely live and
+    // reachable, so without this every test invocation would attempt a
+    // real HTTP round trip, adding latency and flakiness unrelated to
+    // what the test is actually verifying.
+    cmd.env("MCP2CLI_TELEMETRY", "off");
     cmd
 }
 
@@ -137,6 +143,7 @@ pub fn mcp2cli_with_config(
     let mut cmd = assert_cmd::Command::cargo_bin("mcp2cli").expect("binary should be built");
     cmd.env("MCP2CLI_CONFIG_DIR", fixture.config_dir());
     cmd.env("MCP2CLI_DATA_DIR", fixture.data_dir());
+    cmd.env("MCP2CLI_TELEMETRY", "off");
     cmd.arg(config_name);
     cmd.arg("--config");
     cmd.arg(config_path);


### PR DESCRIPTION
## Summary

Re-engineers telemetry reporting per the tsok observability stack's updated integration instructions (dedicated `telemetry.mcp2cli.dev` endpoint, `service.namespace` routing), plus two things found while implementing it that were worth fixing in the same pass.

**Endpoint migration**
- Default collector: `otel.mcp2cli.dev` → `telemetry.mcp2cli.dev/v1/traces`.
- Added the required `service.namespace = "mcp2cli"` resource attribute — this is what actually files data under the mcp2cli project on the shared backend; the endpoint URL alone does not. **This was missing before**, so telemetry was landing unrouted regardless of which endpoint it hit.
- Found and fixed the same issue in the website's independent OTel exporter (`site/src/lib/site-telemetry.ts`) — same old endpoint, same missing `service.namespace`.
- Renamed the two custom resource attributes (`host.os`/`host.arch` → `mcp2cli.os`/`mcp2cli.arch`) for consistency with the `mcp2cli.*` span-attribute namespace.

**Reliability bug (caught by manual end-to-end testing, not the existing test suite)**
Shipping ran on a detached `std::thread` so the CLI's real work never waits on network I/O — but a short-lived CLI process exits and kills that thread before its HTTP round trip can finish. I confirmed this concretely: ran real invocations against the live endpoint and the local `telemetry.ndjson` file never emptied, even after the process exited and I waited several seconds. Telemetry was accumulating locally but essentially never actually shipping.

Added `TelemetryRecorder::flush()` — a short bounded wait (250ms) for in-flight shipping threads, called once at the end of `app::run()`, *after* the command's own output is already on screen (so it doesn't delay what the user sees, only the shell prompt returning). Re-verified: local file now empties reliably, with each invocation still completing in ~35ms. Two new regression tests cover both halves of the contract (`flush_waits_for_shipping_to_actually_complete`, `flush_returns_promptly_when_the_collector_never_responds`).

**New insight, zero new privacy surface**
Negotiated MCP protocol era (`legacy` 2025-11-25 vs `modern` 2026-07-28) is now recorded per command — directly useful for tracking 2026-07-28 adoption, which we just landed. Also wired up `profile_active`/`daemon_active`, which were declared in the schema but hardcoded to `false` since telemetry was first added (dead fields, silently always reporting no signal).

**Privacy**
Explicit tests assert the shipped OTLP resource attributes never include `host.name`, `host.id`, `process.pid`, `user.name`, or `os.description`. Docs updated with the same guarantee, plus corrected the "Option B: Built-in HTTP Shipping" section, which described the wire format as a plain JSON array — it has always actually sent real OTLP `resourceSpans`, that was just a doc bug I found while rewriting this section.

## Test plan

- [x] `cargo test` — 239 tests pass, including 8 new/changed telemetry tests
- [x] `cargo clippy --all-targets` and `cargo fmt --check` clean
- [x] Verified `https://telemetry.mcp2cli.dev/v1/traces` is live with the exact curl from the instructions (200)
- [x] Manual end-to-end: ran real CLI invocations against the live endpoint before and after the `flush()` fix — confirmed the local ndjson file now reliably empties (shipped) vs. never emptying (pre-fix)
- [x] Confirmed `--no-telemetry` opt-out still makes zero local writes and zero network calls

https://claude.ai/code/session_01RLNHojjP1TATtTNDQh1wMY